### PR TITLE
temp solution to twitter timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -928,11 +928,15 @@
 <section class = "bg-secondary ">
 <!-- TWITTER INSTAGRAM -->
     <div class="wrapper">
-      <div class="flex-container justify-content-center align-items-center">
+      <div class="flex-container">
         <div class="col-lg-12">
           <div class="col-md-6">
-            <a class="twitter-timeline" href="https://twitter.com/helpinghands?ref_src=twsrc%5Etfw" height='600px'>Tweets by helpinghands</a>
-            <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            <!-- twitter timeline plugin does not work, commentating out until twitterdev addresses this -->
+            <!-- <a class="twitter-timeline" href="https://twitter.com/helpinghands?ref_src=twsrc%5Etfw" height='600px' width='500px'>Tweets by helpinghands</a> -->
+            <!-- <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> -->
+            <!-- temporary solution to twitter timeline plugin issue -->
+            <a href="https://twitter.com/helpinghands?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @helpinghands</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            <blockquote class="twitter-tweet"><p lang="en" dir="ltr">📢 Calling all youth! Join our info session, earn volunteer hours, and make a real impact. Engage in exciting projects, receive training, and get rewarded. Apply now!<a href="https://twitter.com/hashtag/OntarioYouth?src=hash&amp;ref_src=twsrc%5Etfw">#OntarioYouth</a> <a href="https://twitter.com/hashtag/VolunteerOpportunity?src=hash&amp;ref_src=twsrc%5Etfw">#VolunteerOpportunity</a> <a href="https://twitter.com/hashtag/share?src=hash&amp;ref_src=twsrc%5Etfw">#share</a> <a href="https://twitter.com/hashtag/helpinghands?src=hash&amp;ref_src=twsrc%5Etfw">#helpinghands</a> <a href="https://twitter.com/hashtag/canadaservicecorps?src=hash&amp;ref_src=twsrc%5Etfw">#canadaservicecorps</a> <a href="https://twitter.com/hashtag/Volunteer?src=hash&amp;ref_src=twsrc%5Etfw">#Volunteer</a> <a href="https://t.co/f5l3jBwRyj">pic.twitter.com/f5l3jBwRyj</a></p>&mdash; Helping Hands (@helpinghands) <a href="https://twitter.com/helpinghands/status/1678888336453169152?ref_src=twsrc%5Etfw">July 11, 2023</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
           </div>
 
           <div class="col-md-6">


### PR DESCRIPTION
twitter timeline plugin is currently not working as per twitterdev.
temporary solution is to fill the space with a different twitter plugin focused on specific tweet vs. timeline tweets.