### PR TITLE
Make fields required for Formspree

### DIFF
--- a/contactus.html
+++ b/contactus.html
@@ -137,7 +137,7 @@
                 </p>
                 <div class="help-form">
                   <form
-                    action="https://formspree.io/info@helpinghandsapp.com"
+                    action="https://formspree.io/f/info@helpinghandsapp.com"
                     method="POST"
                   >
                     <script type="text/javascript">
@@ -154,6 +154,7 @@
                       type="text"
                       name="Name"
                       placeholder="Name"
+                      required
                     />
 
                     <label class="visuallyHidden" for="emailInput">Email</label>
@@ -162,6 +163,7 @@
                       type="email"
                       name="Email"
                       placeholder="Email"
+                      required
                     />
 
                     <label class="visuallyHidden" for="messageInput"
@@ -172,6 +174,7 @@
                       placeholder="Message"
                       name="Message"
                       onkeyup="adjust_textarea(this)"
+                      required
                     ></textarea>
 
                     <label class="visuallyHidden" for="submitInput">Send</label>

--- a/contactus.html
+++ b/contactus.html
@@ -137,7 +137,7 @@
                 </p>
                 <div class="help-form">
                   <form
-                    action="https://formspree.io/f/info@helpinghandsapp.com"
+                    action="https://formspree.io/info@helpinghandsapp.com"
                     method="POST"
                   >
                     <script type="text/javascript">

--- a/workshops.html
+++ b/workshops.html
@@ -128,7 +128,7 @@
                   <h3 class="main-title">Tailor them to the Audience</h3>
                   <p id="app-info-card-description">
                     Depending on your school, organization or the campaign
-                    you’re undertaking, we’ll customize our workshop to cater to
+                    you're undertaking, we'll customize our workshop to cater to
                     the theme and topic.
                   </p>
                 </li>
@@ -139,8 +139,8 @@
                   <p id="app-info-card-description">
                     We work to educate students on the larger picture of
                     volunteering, which includes volunteering for their
-                    interests and skills they’d like to develop as well as the
-                    issues they’d like to tackle in their communities.
+                    interests and skills they'd like to develop as well as the
+                    issues they'd like to tackle in their communities.
                   </p>
                 </li>
                 <li class="workshop-card">
@@ -237,6 +237,7 @@
                     type="text"
                     name="Name"
                     placeholder="Name"
+                    required
                   />
 
                   <label class="visuallyHidden" for="emailInput">Email</label>
@@ -245,6 +246,7 @@
                     type="email"
                     name="Email"
                     placeholder="Email"
+                    required
                   />
 
                   <label class="visuallyHidden" for="phoneNumberInput"
@@ -265,6 +267,7 @@
                     type="text"
                     name="School or Organization"
                     placeholder="School or Organization"
+                    required
                   />
 
                   <!--Checkboxes-->


### PR DESCRIPTION
Made all fields required for contactus.html. Made "Name", "Email" and "School or Organization" required for workshops.html. Also replaced curly apostrophes with single quotes in workshops.html.