### PR TITLE
Delete twitter plugin, center instagram plugin

### DIFF
--- a/contactus.html
+++ b/contactus.html
@@ -190,53 +190,33 @@
       <!--============================================================================================-->
 
       <section id="social-media-embed" class="contact bg-primary">
-        <div class="wrapper">
-          <div class="flex-container justify-content-center align-items-center">
-            <div class="col-lg-12">
-              <div class="col-md-6">
-                <a
-                  class="twitter-timeline"
-                  href="https://twitter.com/helpinghands?ref_src=twsrc%5Etfw"
-                  height="600px"
-                  >Tweets by helpinghands</a
-                >
-                <script
-                  async
-                  src="https://platform.twitter.com/widgets.js"
-                  charset="utf-8"
-                ></script>
-              </div>
-
-              <div class="col-md-6">
-                <!-- SnapWidget -->
-                <h4 class="center-block display-flex-center">
-                  Follow Us
-                  <a
-                    class="instagram-handle"
-                    href="https://www.instagram.com/helpinghandsapp/"
-                    aria-label="Find us on Instagram"
-                    target="_blank"
-                    >@HelpingHandsApp</a
-                  >
-                </h4>
-                <script src="https://snapwidget.com/js/snapwidget.js"></script>
-                <iframe
-                  id="ig-feed"
-                  class="ig-feed center-block display-flex-center"
-                  title="Instagram Feed"
-                  src="https://snapwidget.com/embed/723684"
-                  allowtransparency="true"
-                  frameborder="0"
-                  scrolling="no"
-                ></iframe>
-              </div>
-            </div>
-          </div>
+        <div class="wrapper text-center">
+          <!-- SnapWidget -->
+          <h4>
+            Follow Us
+            <a
+              class="instagram-handle"
+              href="https://www.instagram.com/helpinghandsapp/"
+              aria-label="Find us on Instagram"
+              target="_blank"
+            >
+              @HelpingHandsApp
+            </a>
+          </h4>
+          <script src="https://snapwidget.com/js/snapwidget.js"></script>
+          <iframe
+            id="ig-feed"
+            class="ig-feed center-block display-flex-center"
+            title="Instagram Feed"
+            src="https://snapwidget.com/embed/723684"
+            allowtransparency="true"
+            frameborder="0"
+            scrolling="no"
+          ></iframe>
         </div>
       </section>
     </main>
 
-    <!--============================================================================================-->
     <!-- FOOTER -->
     <div id="footer-container"></div>
 


### PR DESCRIPTION
The twitter account is no longer active, so the plugin for tweets has been removed from the contactus.html page.